### PR TITLE
Add switch to set slew rate in APPM.

### DIFF
--- a/Resources/OptionsDataTemplates.xaml
+++ b/Resources/OptionsDataTemplates.xaml
@@ -49,6 +49,7 @@
                                         <RowDefinition />
                                         <RowDefinition />
                                         <RowDefinition />
+                                        <RowDefinition />
                                     </Grid.RowDefinitions>
 
                                     <TextBlock
@@ -56,9 +57,22 @@
                                         Grid.Column="0"
                                         Margin="0,0,0,5"
                                         VerticalAlignment="Center"
+                                        Text="Set slew rate" />
+                                    <CheckBox
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Margin="0,0,0,5"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Left"
+                                        IsChecked="{Binding AppmSetSlewRate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    <TextBlock
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        Margin="0,0,0,5"
+                                        VerticalAlignment="Center"
                                         Text="Slew rate" />
                                     <ninactrl:IntStepperControl
-                                        Grid.Row="0"
+                                        Grid.Row="1"
                                         Grid.Column="1"
                                         Margin="0,0,0,5"
                                         MaxValue="1200"
@@ -68,13 +82,13 @@
                                         Value="{Binding AppmSlewRate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                                     <TextBlock
-                                        Grid.Row="1"
+                                        Grid.Row="2"
                                         Grid.Column="0"
                                         Margin="0,0,0,5"
                                         VerticalAlignment="Center"
                                         Text="Slew settle time" />
                                     <ninactrl:IntStepperControl
-                                        Grid.Row="1"
+                                        Grid.Row="2"
                                         Grid.Column="1"
                                         Margin="0,0,0,5"
                                         MaxValue="300"
@@ -84,13 +98,13 @@
                                         Value="{Binding AppmSlewSettleTime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                                     <TextBlock
-                                        Grid.Row="2"
+                                        Grid.Row="3"
                                         Grid.Column="0"
                                         Margin="0,0,0,5"
                                         VerticalAlignment="Center"
                                         Text="Use meridian limits" />
                                     <CheckBox
-                                        Grid.Row="2"
+                                        Grid.Row="3"
                                         Grid.Column="1"
                                         Margin="0,5,0,5"
                                         VerticalAlignment="Center"


### PR DESCRIPTION
## What is the purpose of this Pull Request?

Adds a switch in the options page allowing users to set whether APPM updates the slew rate of the mount. Useful to disable for the Mach2GTO, which has a faster max slew rate than APPM can set.

## How were the changes tested?

Tested with a Mach2GTO tonight.

## Screenshot

![Screenshot 2022-09-21 021251](https://user-images.githubusercontent.com/25827426/191439572-8e89e4e8-a479-4b91-afc3-7bc761eecdaf.png)